### PR TITLE
Correct/add copyright messages

### DIFF
--- a/src/main/java/tech/ndau/address/Address.java
+++ b/src/main/java/tech/ndau/address/Address.java
@@ -6,7 +6,7 @@
  * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Lesser General Public License 3.0 for more details.
  *
- * Copyright © 2019 Oneiro NA, Inc.
+ * Copyright © 2020 The Axiom Foundation
  */
 
 package tech.ndau.address;

--- a/src/main/java/tech/ndau/address/Checksum.java
+++ b/src/main/java/tech/ndau/address/Checksum.java
@@ -6,7 +6,7 @@
  * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Lesser General Public License 3.0 for more details.
  *
- * Copyright © 2019 Oneiro NA, Inc.
+ * Copyright © 2020 The Axiom Foundation
  */
 
 package tech.ndau.address;

--- a/src/main/java/tech/ndau/address/InvalidAddress.java
+++ b/src/main/java/tech/ndau/address/InvalidAddress.java
@@ -6,7 +6,7 @@
  * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Lesser General Public License 3.0 for more details.
  *
- * Copyright © 2019 Oneiro NA, Inc.
+ * Copyright © 2020 The Axiom Foundation
  */
 
 package tech.ndau.address;

--- a/src/main/java/tech/ndau/b32/Base32.java
+++ b/src/main/java/tech/ndau/b32/Base32.java
@@ -6,7 +6,7 @@
  * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Lesser General Public License 3.0 for more details.
  *
- * Copyright © 2019 Oneiro NA, Inc.
+ * Copyright © 2020 The Axiom Foundation
  */
 
 package tech.ndau.b32;

--- a/src/main/java/tech/ndau/b32/CorruptInputError.java
+++ b/src/main/java/tech/ndau/b32/CorruptInputError.java
@@ -6,7 +6,7 @@
  * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Lesser General Public License 3.0 for more details.
  *
- * Copyright © 2019 Oneiro NA, Inc.
+ * Copyright © 2020 The Axiom Foundation
  */
 
 package tech.ndau.b32;


### PR DESCRIPTION
This code is used to support Bisq and must be licensed under the (L)GPL. These edits only update the copyright messages.